### PR TITLE
fix matthiaaas/otto-assistant#4 - better way to find locale

### DIFF
--- a/assistant/core/commands/cmd_date.py
+++ b/assistant/core/commands/cmd_date.py
@@ -12,7 +12,15 @@ says the date
 """
 def ex(cmd):
     # set locale to get the right month names
-    locale.setlocale(locale.LC_TIME, settings.LANGUAGE.replace("-", "_"))
+    # Name of locale depends on system. i.e. Id had an error with de-DE, because my locale is named
+    # de_DE.utf-8, so try this if it fails without.
+    try:
+        locale.setlocale(locale.LC_TIME, settings.LANGUAGE.replace("-", "_"))
+    except locale.Error:
+        try:
+            locale.setlocale(locale.LC_TIME, settings.LANGUAGE.replace("-", "_") + ".utf-8")
+        except locale.Error:
+            print("Your locale was not found, using default locale")
 
     # get the date
     date = datetime.now()

--- a/assistant/core/commands/cmd_date.py
+++ b/assistant/core/commands/cmd_date.py
@@ -12,8 +12,6 @@ says the date
 """
 def ex(cmd):
     # set locale to get the right month names
-    # Name of locale depends on system. i.e. Id had an error with de-DE, because my locale is named
-    # de_DE.utf-8, so try this if it fails without.
     try:
         locale.setlocale(locale.LC_TIME, settings.LANGUAGE.replace("-", "_"))
     except locale.Error:


### PR DESCRIPTION
fix matthiaaas/otto-assistant#4 - better way to find locale:

On some systems, some locales are not called de_DE, but de_DE.utf-8, so try this.
If this fails, give the user a hint.
Also catch the error that causes a crash as described in #4 